### PR TITLE
Features/christopher

### DIFF
--- a/src/test/java/com/sparta/steps/CreateRepoStepDefs.java
+++ b/src/test/java/com/sparta/steps/CreateRepoStepDefs.java
@@ -122,11 +122,6 @@ public class CreateRepoStepDefs extends TestBase {
         assertThat(response.path("data.createRepository.repository.visibility"), is("PRIVATE"));
     }
 
-    @After("@Create and not @Keep")
-    public void cleanUp(){
-        GitHubRestClient.deleteRepository(OWNER, repoName);
-    }
-
     @And("no Description")
     public void noDescription() {
         description = "";
@@ -217,5 +212,10 @@ public class CreateRepoStepDefs extends TestBase {
     @Then("I should receive an error saying Name can't be blank")
     public void iShouldReceiveAnErrorSayingNameCanTBeBlank() {
         assertThat(response.path("errors[0].message"),is("Name can't be blank, Name is too short (minimum is 1 character)"));
+    }
+
+    @After("@Create and not @Keep")
+    public void cleanUp(){
+        GitHubRestClient.deleteRepository(OWNER, repoName);
     }
 }

--- a/src/test/java/com/sparta/steps/CreateRepoStepDefs.java
+++ b/src/test/java/com/sparta/steps/CreateRepoStepDefs.java
@@ -122,7 +122,7 @@ public class CreateRepoStepDefs extends TestBase {
         assertThat(response.path("data.createRepository.repository.visibility"), is("PRIVATE"));
     }
 
-    @After("not @Keep")
+    @After("@Create and not @Keep")
     public void cleanUp(){
         GitHubRestClient.deleteRepository(OWNER, repoName);
     }

--- a/src/test/java/com/sparta/steps/CreateRepoStepDefs.java
+++ b/src/test/java/com/sparta/steps/CreateRepoStepDefs.java
@@ -190,8 +190,18 @@ public class CreateRepoStepDefs extends TestBase {
 
 
     @And("a Repository Name that already Exists")
-    public void aRepositoryNameThatAlreadyExists() {
+    public void aRepositoryNameThatAlreadyExists() throws IOException {
+
         repoName = "GraphQL-Repository-that-already-exists";
+        description = "A repository that exists so that I can try and hopefully fail to duplicate it";
+        query = readQuery("CreateRepo.graphql");
+        variables = Map.of(
+                "name",repoName,
+                "visibility",visibility,
+                "description", description
+        );
+
+        response = executeQuery(query,"CreateRepository",variables);
     }
 
     @Then("I should receive an error saying Name already exists on this account")

--- a/src/test/resources/features/CreateRepo.feature
+++ b/src/test/resources/features/CreateRepo.feature
@@ -5,6 +5,7 @@ Feature: Create New Repository
   So that I can automate the github process from the start
 
   @Happy
+  @Create
   Scenario: Query runs correctly
     Given a valid Github Token
     And a valid Repository Name
@@ -15,6 +16,7 @@ Feature: Create New Repository
     And I should receive a repository object
 
   @Happy
+  @Create
   Scenario: Returned Repositories must include key fields
     Given a valid Github Token
     And a valid Repository Name
@@ -28,6 +30,7 @@ Feature: Create New Repository
     And the Visibility should be Private
 
   @Happy
+  @Create
   Scenario: Creating a Repository works fine without a description
     Given a valid Github Token
     And a valid Repository Name
@@ -38,6 +41,7 @@ Feature: Create New Repository
     Then the response should have a null description
 
   @Happy
+  @Create
   Scenario: Creating a Public Repository
     Given a valid Github Token
     And a valid Repository Name
@@ -47,6 +51,7 @@ Feature: Create New Repository
     Then the response should have visibility set to Public
 
   @Sad
+  @Create
   Scenario: Unauthorised Requests Fail
     Given an Invalid Github Token
     And a valid Repository Name
@@ -55,6 +60,7 @@ Feature: Create New Repository
     Then the status code of the response should be 401
 
   @Sad
+  @Create
   @Keep
   Scenario: No Duplicate Repository Names
     Given a valid Github Token
@@ -64,6 +70,7 @@ Feature: Create New Repository
     Then I should receive an error saying Name already exists on this account
 
   @Sad
+  @Create
   Scenario: Attempting to Create a Repository with No Name
     Given a valid Github Token
     And a Blank repository name

--- a/src/test/resources/features/CreateRepo.feature
+++ b/src/test/resources/features/CreateRepo.feature
@@ -61,7 +61,6 @@ Feature: Create New Repository
 
   @Sad
   @Create
-  @Keep
   Scenario: No Duplicate Repository Names
     Given a valid Github Token
     And a Repository Name that already Exists


### PR DESCRIPTION
Removed dependency on needing an existing repository when testing that you can't create a duplicate repository - now that test creates a new repository, tries to make a duplicate, checks it failed to do so, then deletes the first repository

Also made explicit in the code that the @After function for Create Scenarios only runs after Create scenarios.